### PR TITLE
Add flag to cap max render fps

### DIFF
--- a/src/cli/mod.rs
+++ b/src/cli/mod.rs
@@ -94,6 +94,10 @@ static WINDOW_HEIGHT_OPT: Opt = Opt {
     short: "", long: "window-height", flag: false,
     help: "--window-height <height>  height in pixels of viewer window",
 };
+static MAX_RENDER_FPS_OPT: Opt = Opt {
+    short: "", long: "max-render-fps", flag: false,
+    help: "--max-render-fps <fps>    maximum speed in frames/second to render the viewer at",
+};
 static ANIMATION_FPS_OPT: Opt = Opt {
     short: "", long: "animation-fps", flag: false,
     help: "--animation-fps <fps>     speed in frames/second to play animations at",
@@ -215,7 +219,7 @@ fn show_info_help_and_exit() -> ! {
 }
 
 
-static VIEW_OPTS: &[&Opt] = &[&ALL_ANIMATIONS_OPT, &WINDOW_WIDTH_OPT, &WINDOW_HEIGHT_OPT, &ANIMATION_FPS_OPT, &BG_COLOR_OPT, &HELP_OPT];
+static VIEW_OPTS: &[&Opt] = &[&ALL_ANIMATIONS_OPT, &WINDOW_WIDTH_OPT, &WINDOW_HEIGHT_OPT, &ANIMATION_FPS_OPT, &MAX_RENDER_FPS_OPT, &BG_COLOR_OPT, &HELP_OPT];
 
 fn view(p: &mut Parse) {
     parse_opts(p, VIEW_OPTS);

--- a/src/viewer/config.rs
+++ b/src/viewer/config.rs
@@ -21,6 +21,8 @@ pub struct Config {
     pub fov_y: f32,
     /// Animation framerate (seconds/frame)
     pub animation_framerate: f64,
+    /// Limits the maximum FPS the viewer is rendered at in order to reduce CPU usage (seconds/frame).
+    pub max_render_framerate: Option<f64>,
     /// Calculate FPS over intervals of this length (seconds).
     pub fps_interval: f64,
 }
@@ -35,6 +37,7 @@ impl Default for Config {
             z_far: 4000.0,
             fov_y: 1.1,
             animation_framerate: 1.0 / 60.0,
+            max_render_framerate: None,
             fps_interval: 2.0,
         }
     }
@@ -49,6 +52,7 @@ impl Config {
                 "window-width" => {config.window_width = value.clone().into_string().unwrap().parse::<u32>()?},
                 "window-height" => {config.window_height = value.clone().into_string().unwrap().parse::<u32>()?},
                 "animation-fps" => {config.animation_framerate = 1.0 / value.clone().into_string().unwrap().parse::<f64>()?},
+                "max-render-fps" => {config.max_render_framerate = Some(1.0 / value.clone().into_string().unwrap().parse::<f64>()?)},
                 "bg-color" => {config.bg_color = hex_code_to_color(&value.clone().into_string().unwrap())?},
                 _ => {},
             }

--- a/src/viewer/main_loop.rs
+++ b/src/viewer/main_loop.rs
@@ -44,9 +44,22 @@ pub fn main_loop(config: &Config, db: Database, conn: Connection) {
             Ev::WindowEvent { event, .. } => match event {
                 WEv::RedrawRequested => {
                     state.last_time = state.cur_time;
-                    state.cur_time = time::precise_time_ns();
-                    let dt_in_ns = state.cur_time.wrapping_sub(state.last_time);
-                    let dt = dt_in_ns as f64 / 1_000_000_000.0;
+
+                    let mut dt;
+                    loop {
+                        state.cur_time = time::precise_time_ns();
+                        let dt_in_ns = state.cur_time.wrapping_sub(state.last_time);
+                        dt = dt_in_ns as f64 / 1_000_000_000.0;
+
+                        match config.max_render_framerate {
+                            Some(max_render_framerate) => {
+                                if dt >= max_render_framerate {
+                                    break
+                                }
+                            },
+                            _ => {break}
+                        }
+                    }
 
                     viewer.update(&display, dt);
 


### PR DESCRIPTION
Adds a new flag `--max-render-fps` to cap the maximum render fps of the viewer.